### PR TITLE
Ship extensions

### DIFF
--- a/ext/src/org/lazywizard/lazylib/ext/KotlinExtensions.kt
+++ b/ext/src/org/lazywizard/lazylib/ext/KotlinExtensions.kt
@@ -1,0 +1,17 @@
+package org.lazywizard.lazylib.ext
+
+/**
+ * Null-safely checks for equality, covering the case when either (or both) of the objects are null.
+ */
+fun Any?.safeEquals(other: Any?): Boolean {
+    // Check if both objects are null
+    if (this == null && other == null) {
+        return true
+    }
+    // Check if one of the objects is null
+    if (this == null || other == null) {
+        return false
+    }
+    // Use the regular equals() method to compare non-null objects
+    return this == other
+}

--- a/ext/src/org/lazywizard/lazylib/ext/ShipExtensions.kt
+++ b/ext/src/org/lazywizard/lazylib/ext/ShipExtensions.kt
@@ -1,0 +1,43 @@
+package org.lazywizard.lazylib.ext
+
+import com.fs.starfarer.api.combat.ShipAPI
+import org.lwjgl.util.vector.Vector2f
+
+
+/**
+ * Returns the [Vector2f] of where the ship is looking (facing) at
+ * @return the ship's forward vector, similar to [com.fs.starfarer.api.util.Misc.getUnitVectorAtDegreeAngle] used with the ship's [ShipAPI.getFacing]
+ */
+fun ShipAPI.getForwardVector(): Vector2f {
+    val rotationRadians = Math.toRadians(this.facing.toDouble())
+
+    // Calculate the components of the forward vector
+    val x = cos(rotationRadians).toFloat()
+    val y = sin(rotationRadians).toFloat()
+
+    // Return the forward vector
+    return Vector2f(x, y)
+}
+
+/**
+ * Returns the angle (in degrees) between this ship's Forward Vector and *anotherShip*
+ * @return the difference in degrees
+ * @see [ShipAPI.getForwardVector]
+ */
+fun ShipAPI.getAngleToAnotherShip(anotherShip: ShipAPI): Float {
+    val targetDirectionAngle = VectorUtils.getAngle(this.location, anotherShip.location)
+    val myForwardVector = this.getForwardVector()
+    val myAngle = VectorUtils.getAngle(myForwardVector, anotherShip.location)
+    val differenceInDegrees = (myAngle - targetDirectionAngle)
+
+    return differenceInDegrees
+}
+
+/**
+ * Returns the absolue angle (in degrees) between this ship and *anotherShip*
+ * @return the difference in degrees, as absolute value
+ * @see [ShipAPI.getAngleToAnotherShip]
+ */
+fun ShipAPI.getAbsoluteAngleToAnotherShip(anotherShip: ShipAPI): Float {
+    return this.getAngleToAnotherShip(anotherShip).absoluteValue
+}


### PR DESCRIPTION
This PR adds a new file containing a few useful kotlin extension functions for the `ShipAPI` class. The new utility functions were lacking in both MathUtil and VectorUtil. 

The added functions are:
- `getForwardVector()` - returns a `Vector2f` of where the (calling) ship is facing
- `getAngleToAnotherShip(ShipAPI anotherShip)` - returns the angle between the (calling) ship and *anotherShip*
- `getAbsoluteAngleToAnotherShip(ShipAPI anotherShip)` - similar to previous one, except it returns an absolute angle

Also threw in a KotlinExtensions with the safeEquals method which null-safely checks for equality and works for when either or both of the involved objects are null.

Finally, the same methods are added for Java too, in appropriate files (MathUtils and VectorUtils)