### PR TITLE
Read font width and height from metadata, not texture

### DIFF
--- a/src/org/lazywizard/lazylib/ui/LazyFont.kt
+++ b/src/org/lazywizard/lazylib/ui/LazyFont.kt
@@ -102,19 +102,17 @@ class LazyFont private constructor(
                 // TODO: Add support for multiple image files; 'pages' in the font file
                 // (this is a low priority as no vanilla font uses multiple pages)
                 val textureId: Int
-                val textureWidth: Float
-                val textureHeight: Float
                 try {
                     Global.getSettings().loadTexture(imgFile)
                     val texture = Global.getSettings().getSprite(imgFile)
                     textureId = texture.textureId
-                    textureWidth = texture.width
-                    textureHeight = texture.height
                 } catch (ex: IOException) {
                     throw FontException("Failed to load texture atlas '$imgFile'", ex)
                 }
 
-                val font = LazyFont(fontName, textureId, baseHeight, textureWidth, textureHeight)
+                val scaleW = java.lang.Float.parseFloat(metadata[31])
+                val scaleH = java.lang.Float.parseFloat(metadata[33])
+                val font = LazyFont(fontName, textureId, baseHeight, scaleW, scaleH)
                 Log.debug("Created empty font ${font.fontName} from $fontPath, preparing to add character data")
 
                 // Parse character data and place into a quick lookup table or extended character map


### PR DESCRIPTION
Resolves issue https://github.com/LazyWizard/lazylib/issues/5; uses the base game's logic for handling font texture atlas resolutions that do not match the underlying .fnt metadata. Should allow for consistent font rendering between vanilla and modded content if any underlying textures change their resolutions.